### PR TITLE
Activate `clang-sys`'s `runtime` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/drahnr/hunspell-rs"
 edition = "2021"
 
 [dependencies]
-hunspell-sys = { version = "0.3.0", default-features = false }
+hunspell-sys = "0.3.0"
 log = "0.4.17"
 
 [features]


### PR DESCRIPTION
This feature was added in euclio/hunspell-sys#6, but is not activated here. Without this feature, which ultimately activates the `runtime` feature in `clang-sys`, bindgen is not able to find libclang on my system.

## Error message

```console
$ cargo install --locked cargo-spellcheck
    Updating crates.io index
  Installing cargo-spellcheck v0.12.3
# snip ...
error: failed to run custom build command for `hunspell-sys v0.3.1`

Caused by:
  process didn't exit successfully: `/var/folders/qh/w7p29fd50d30px6kq781sx8m0000gn/T/cargo-installYTwckG/release/build/hunspell-sys-71253c33aed42210/build-script-build` (signal: 6, SIGABRT: process abort signal)
  --- stderr
  dyld[3769]: Library not loaded: @rpath/libclang.dylib
    Referenced from: <AF7F6DA1-0584-314D-BC20-3A4F7AA5D4F0> /private/var/folders/qh/w7p29fd50d30px6kq781sx8m0000gn/T/cargo-installYTwckG/release/build/hunspell-sys-71253c33aed42210/build-script-build
    Reason: tried: '/var/folders/qh/w7p29fd50d30px6kq781sx8m0000gn/T/cargo-installYTwckG/release/deps/libclang.dylib' (no such file), '/var/folders/qh/w7p29fd50d30px6kq781sx8m0000gn/T/cargo-installYTwckG/release/libclang.dylib' (no such file), '/Users/lopopolo/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libclang.dylib' (no such file), '/Users/lopopolo/.rustup/toolchains/stable-x86_64-apple-darwin/lib/libclang.dylib' (no such file), '/Users/lopopolo/lib/libclang.dylib' (no such file), '/usr/local/lib/libclang.dylib' (no such file), '/usr/lib/libclang.dylib' (no such file, not in dyld cache)
warning: build failed, waiting for other jobs to finish...
error: failed to compile `cargo-spellcheck v0.12.3`, intermediate artifacts can be found at `/var/folders/qh/w7p29fd50d30px6kq781sx8m0000gn/T/cargo-installYTwckG`
```